### PR TITLE
Update standards

### DIFF
--- a/Infinum/ruleset.xml
+++ b/Infinum/ruleset.xml
@@ -88,6 +88,22 @@
     <!-- Disallow spacing inside arrays. -->
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 
+    <!-- Private methods MUST not be prefixed with an underscore -->
+    <rule ref="Squiz.NamingConventions.ValidFunctionName.PrivateNoUnderscore">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+        <type>error</type>
+    </rule>
+
+    <!-- Private properties MUST not be prefixed with an underscore -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+        <type>error</type>
+    </rule>
+
     <!-- Ensure proper object instantiation. -->
     <rule ref="WordPress.Classes.ClassInstantiation"/>
 

--- a/tests/code-example-6.php
+++ b/tests/code-example-6.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Test
+ *
+ * @package Test
+ */
+
+ namespace A;
+
+/**
+ * Class
+ */
+class ClassName
+{
+	/**
+	 * Service array
+	 *
+	 * @var array Services
+	 */
+	private $service = [];
+
+	/**
+	 * Method name
+	 */
+	private function doSomethingPrivate()
+	{
+		return '';
+	}
+}


### PR DESCRIPTION
Add the rule to prevent the usage of underscores to denote private methods/properties. 

The visibility modifier is used for this, not underscores.